### PR TITLE
strict int parsing

### DIFF
--- a/pynetstring.py
+++ b/pynetstring.py
@@ -80,7 +80,8 @@ class Decoder:
                         self._state = State.PARSE_DATA
                         break
                     else:
-                        raise BadLength("Inappropriate symbol met in netstring length: %s" % repr(chr(sym)))
+                        raise BadLength("Inappropriate symbol met in netstring "
+                                        "length: %s" % repr(bytes((sym,))))
                 else:
                     # Entire buffer was scanned, but no complete length was read
                     break

--- a/pynetstring.py
+++ b/pynetstring.py
@@ -1,5 +1,9 @@
 from enum import Enum
-import math
+
+ZERO = ord(b'0')
+NINE = ord(b'9')
+COLON = ord(b':')
+COMMA = ord(b',')
 
 def _encode(data):
     if isinstance(data, str):
@@ -24,6 +28,10 @@ class TooLong(ParseError):
     pass
 
 
+class BadLength(ParseError):
+    pass
+
+
 class IncompleteString(ParseError):
     pass
 
@@ -40,7 +48,7 @@ class Decoder:
         self._length = None
         self._decoded = []
         self._maxlen = maxlen
-        self._maxlen_bytes = math.log10(self._maxlen) + 1 if self._maxlen else 0
+        self._data_offset = 0
 
     def feed(self, data):
 
@@ -51,41 +59,42 @@ class Decoder:
 
         while True:
             if self._state == State.PARSE_LENGTH:
-                length_end = self._buffer.find(b':')
-                if length_end == -1:
-                    # There is not enough data yet to decode the length
-                    # Compact leading zeroes in buffer
-                    self._buffer = self._buffer[:-1].lstrip(b'0') + self._buffer[-1:]
-                    # Check if length field already too long:
-                    if self._maxlen_bytes and len(self._buffer) > self._maxlen_bytes:
-                        raise TooLong("Read too many bytes but length end"
-                                      " marker wasn't met.")
-                    break
+                self._data_offset = 0
+                self._length = None
+                for sym in self._buffer:
+                    self._data_offset += 1
+                    # Avoid copy of entire buffer to cut data portion.
+                    # Just track offset and use it when final string about to
+                    # be extracted
+                    if ZERO <= sym <= NINE:
+                        if self._length is None:
+                            self._length = sym - ZERO
+                        else:
+                            self._length = self._length * 10 + sym - ZERO
+                        if self._maxlen and self._length > self._maxlen:
+                            raise TooLong("Specified netstring length "
+                                          "is over limit.")
+                    elif sym == COLON:
+                        if self._length is None:
+                            raise BadLength("No netstring length bytes read.")
+                        self._state = State.PARSE_DATA
+                        break
+                    else:
+                        raise BadLength("Inappropriate symbol met in netstring length: %s" % repr(chr(sym)))
                 else:
-                    # Only allow characters 0-9 in the length definition
-                    valid_chars = range(ord(b'0'), ord(b'9') + 1)
-                    if not all(char in valid_chars for char in self._buffer[:length_end]):
-                        raise ParseError('Invalid length characters found.')
-
-                    self._length = int(self._buffer[:length_end])
-                    
-                    if self._maxlen and self._length > self._maxlen:
-                        raise TooLong("Specified netstring length is over limit.")
-
-                    # Consume what has been parsed
-                    self._buffer = self._buffer[length_end + 1:]
-                    self._state = State.PARSE_DATA
-
+                    # Entire buffer was scanned, but no complete length was read
+                    break
             if self._state == State.PARSE_DATA:
-                if len(self._buffer) < self._length + 1:
+                data_end = self._data_offset + self._length
+                if len(self._buffer) < data_end + 1:
                     # The entire data part including trailing comma has not yet
                     # been received
                     break
                 else:
-                    if self._buffer[self._length] != ord(b','):
+                    if self._buffer[data_end] != COMMA:
                         raise IncompleteString('Missing trailing comma.')
-                    data = self._buffer[:self._length]
-                    self._buffer = self._buffer[self._length + 1:]
+                    data = self._buffer[self._data_offset:data_end]
+                    self._buffer = self._buffer[data_end + 1:]
                     self._decoded.append(bytes(data))
                     self._state = State.PARSE_LENGTH
 


### PR DESCRIPTION
Resolves #7 

Actual PR removes usage of built-in `int()` function and incorporates direct byte scanning in order to provide value limitation, symbol control and int conversion at once. Other notable changes:
* Removed `self._maxlen_bytes` logic. Now we can control length as new bytes appear and plausible length check is not needed anymore because check of intermediate length value is more strict.
* Performance improvement: avoid copying entire buffer to cut length prefix.
* Performance improvement: avoid scan of entire buffer for colon character. Now we can account it in FSM fashion and break early if it is something wrong with length bytes.