### PR TITLE
Feature: non-buffering streaming parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,24 @@ the constructor:
 The Decoder will raise TooLong exception as soon as it'll discover next string
 can't fit the limit.
 
+**Stream decoding**
+
+pynetstring provides StreamingDecoder class for cases when you need to decode
+stream of netstrings where individual netstring may not fit in memory buffer 
+or parts of it should be extracted before entire netstring appear in one piece.
+
+StreamingDecoder has interface similar to Decoder class, but it's feed() method
+returns parts of decoded netstrings as soon as they are extracted. End of
+individual string signalized with an empty bytestring in sequence. In order to
+collect returned strings you should accumulate fragments from returned sequence
+until empty binary string met. After each empty string in sequence you should
+start over accumulating outputs into a new string.
+
+For example, returned sequence [ b'ab', b'cd', b'', b'!!!!', b'', b'', b'12' ]
+means we have received three complete string b'abcd', b'!!!!' and b'', and
+part of one incomplete netstring b'12' (further parts of which will appear in
+subsequent calls of feed() buffer with new data).
+
 Data encoding
 -------------
 Regardless of the type of the data that is sent to encode(), it will always

--- a/pynetstring.py
+++ b/pynetstring.py
@@ -85,7 +85,7 @@ class StreamingDecoder:
                     # Entire buffer was scanned, but no complete length was read
                     break
             if self._state == State.PARSE_DATA:
-                if not self._length:
+                if self._length == 0:
                     self._state = State.PARSE_TERMINATOR
                 else:
                     bytes_remaining = len_data - input_offset


### PR DESCRIPTION
This PR introduces non-buffering stream parser `StreamingDecoder` which yields parsed parts of netstring immediately. This enables usage of pynetstring for two new kinds of applications:
* Cases with very large netstrings that cannot fit into memory and have to be processed by smaller parts. This particular case demonstrated in `test_100MB_netstring` test. Parser is capable to process multi-gigabyte strings, but I limited test load size to 100MB for sake of tests speed.
* Cases where parts of netstring should be extracted before entire netstring appear in one piece (useful for premature processing).

`StreamingDecoder` class implementation is entirely based on `Decoder` class, so in practice `Decoder` was renamed to `StreamingDecoder` and `Decoder`'s buffering interface was implemented on top of reworked `StreamingDecoder`.

Also this proposed code properly detects incomplete netstrings supplied to `pynetstring.decode`. See `test_decode_incomplete_string_fails` test for examples.

New implementation is 18% slower from my observation (mostly caused by nesting of method calls and by new checks), but adds completeness to functionality, introduces clear state tracking into parsing (now terminator read is a separate state) and resolves ambiguousness of imcomplete string parsing with pynetstring.decode.

P.S. Feel free to reword docs: English is not native for me, so text might be far from best.